### PR TITLE
feat: sign label customize and per git branch noting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ require("lazy").setup({
 
 ## Config
 
-Currently, there is only one config option, but more options might be coming.
+Currently, there is only two config option, but more options might be coming.
 
 ```lua
 require("lazy").setup({
   { "RutaTang/quicknote.nvim", config=function()
         require("quicknote").setup({
-            mode = "portable" -- "portable" | "resident", default to "portable"
+            mode = "portable", -- "portable" | "resident", default to "portable"
+            sign = "N" -- This is used for the signs on the left side (refer to ShowNoteSigns() api).
+                       -- You can change it to whatever you want (eg. some nerd fonts icon), 'N' is default
         })
   end
   , dependencies = { "nvim-lua/plenary.nvim"} },

--- a/lua/quicknote/core/sign.lua
+++ b/lua/quicknote/core/sign.lua
@@ -1,4 +1,5 @@
 local utils_path = require("quicknote.utils.path")
+local utils_config = require("quicknote.utils.config")
 local path = require("plenary.path")
 
 local SIGN_NAME = "QuickNote"
@@ -28,7 +29,7 @@ end
 
 -- define sign
 function M.DefineSign()
-    vim.fn.sign_define(SIGN_NAME, { text = "N", texthl = "QuickNote", linehl = "", numhl = "" })
+    vim.fn.sign_define(SIGN_NAME, { text = utils_config.GetSign(), texthl = "QuickNote", linehl = "", numhl = "" })
 end
 
 -- get sign display state for a buffer

--- a/lua/quicknote/utils/config.lua
+++ b/lua/quicknote/utils/config.lua
@@ -1,6 +1,7 @@
 -- default config
 local config = {
     mode = "portable", -- "resident" or "portable"
+    sign = "N",
 }
 
 -- Export
@@ -26,5 +27,10 @@ local GetMode = function()
     return config.mode
 end
 M.GetMode = GetMode
+
+local GetSign = function()
+    return config.sign
+end
+M.GetSign = GetSign
 
 return M

--- a/lua/quicknote/utils/path.lua
+++ b/lua/quicknote/utils/path.lua
@@ -25,7 +25,18 @@ local getHashedNoteDirPath = function(filePath)
     if config.GetMode() == "portable" then
         filePath = path:new(filePath):make_relative()
     end
-    local noteDirName = sha.sha1(filePath) -- hash current buffer path
+    -- get the current git branch
+    local branch = vim.fn.system("git rev-parse --abbrev-ref HEAD")
+    if vim.v.shell_error == 0 then
+        if branch == "HEAD" then
+            -- the HEAD is detached, use the commit id instead
+            branch = vim.fn.system("git rev-parse HEAD")
+        end
+    else
+        branch = ""
+    end
+    print(filePath)
+    local noteDirName = sha.sha1(filePath .. branch) -- hash current buffer path with git branch
     -- get hashed note dir path
     local noteDirPath = path:new(dataPath, noteDirName).filename
     return noteDirPath

--- a/lua/quicknote/utils/path.lua
+++ b/lua/quicknote/utils/path.lua
@@ -35,7 +35,6 @@ local getHashedNoteDirPath = function(filePath)
     else
         branch = ""
     end
-    print(filePath)
     local noteDirName = sha.sha1(filePath .. branch) -- hash current buffer path with git branch
     -- get hashed note dir path
     local noteDirPath = path:new(dataPath, noteDirName).filename


### PR DESCRIPTION
this pr added two feats
1. sign label customization refering to #6 
2. store note per git branch

sign label customization is done by adding a new config option sign. And then in the `sign_define` function we can define the user supplied sign label.

per git branch storing is done by appending the branch name to the filePath in the `getHashedNoteDirPath` function.
I currently use the `vim.fn.system` to call git and get the branch name. And if the HEAD is detached, use the commit id as branch name.