### PR TITLE
feat(quicknote): Use dynamic file type for note files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ require("lazy").setup({
   { "RutaTang/quicknote.nvim", config=function()
         require("quicknote").setup({
             mode = "portable", -- "portable" | "resident", default to "portable"
-            sign = "N" -- This is used for the signs on the left side (refer to ShowNoteSigns() api).
+            sign = "N", -- This is used for the signs on the left side (refer to ShowNoteSigns() api).
                        -- You can change it to whatever you want (eg. some nerd fonts icon), 'N' is default
+            filetype = "md", 
         })
   end
   , dependencies = { "nvim-lua/plenary.nvim"} },

--- a/lua/quicknote/core/delete.lua
+++ b/lua/quicknote/core/delete.lua
@@ -25,7 +25,7 @@ local M = {}
 local DeleteNoteAtLine = function(line)
     local noteDirPath = utils.path.getNoteDirPathForCurrentBuffer()
     -- get note file path
-    local noteFilePath = path:new(noteDirPath, line .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, line .. "." .. utils.config.GetFileType()).filename
 
     -- check if note file exist
     checkAndDeleteNoteFile(noteFilePath)
@@ -51,7 +51,7 @@ local DeleteNoteAtGlobal = function()
     local noteDirPath = utils.path.getNoteDirPathForGlobal()
 
     -- get note file path
-    local noteFilePath = path:new(noteDirPath, fileName .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, fileName .. "." .. utils.config.GetFileType()).filename
 
     -- check if note file exist
     checkAndDeleteNoteFile(noteFilePath)
@@ -73,7 +73,7 @@ local DeleteNoteAtCWD = function()
     local noteDirPath = utils.path.getNoteDirPathForCWD()
 
     -- get note file path
-    local noteFilePath = path:new(noteDirPath, fileName .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, fileName .. "." .. utils.config.GetFileType()).filename
 
     -- check if note file exist
     checkAndDeleteNoteFile(noteFilePath)

--- a/lua/quicknote/core/new.lua
+++ b/lua/quicknote/core/new.lua
@@ -18,7 +18,7 @@ local NewNoteAtGlobalAsync = function()
     utils.fs.MKDirAsync(noteDirPtha)
 
     -- create note file
-    local noteFilePath = path:new(noteDirPtha, fileName .. ".md").filename
+    local noteFilePath = path:new(noteDirPtha, fileName .. "." .. utils.config.GetFileType()).filename
     utils.fs.CreateFileAsync(noteFilePath)
 end
 M.NewNoteAtGlobal = function()
@@ -41,7 +41,7 @@ local NewNoteAtCWDAsync = function()
     utils.fs.MKDirAsync(noteDirPath)
 
     -- create note files (if not exist)
-    local noteFilePath = path:new(noteDirPath, fileName .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, fileName .. "." .. utils.config.GetFileType()).filename
     utils.fs.CreateFileAsync(noteFilePath)
 end
 M.NewNoteAtCWD = function()
@@ -62,7 +62,7 @@ local NewNoteAtLineAsync = function(line)
     utils.fs.MKDirAsync(noteDirPath)
 
     -- create note file (if not exist)
-    local noteFilePath = path:new(noteDirPath, line .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, line .. "." .. utils.config.GetFileType()).filename
     utils.fs.CreateFileAsync(noteFilePath)
 end
 M.NewNoteAtLine = function(line)

--- a/lua/quicknote/core/open.lua
+++ b/lua/quicknote/core/open.lua
@@ -23,7 +23,7 @@ end
 local OpenNoteAtLine = function(line)
     local noteDirPath = utils.path.getNoteDirPathForCurrentBuffer()
     -- get note file path
-    local noteFilePath = path:new(noteDirPath, line .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, line .. "." .. utils.config.GetFileType()).filename
     -- check if note file exist
     checkAndOpenNoteFile(noteFilePath)
 end
@@ -45,7 +45,7 @@ local OpenNoteAtGlobal = function()
     local noteDirPath = utils.path.getNoteDirPathForGlobal()
 
     -- get note file path
-    local noteFilePath = path:new(noteDirPath, fileName .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, fileName .. "." .. utils.config.GetFileType()).filename
 
     -- check if note file exist
     checkAndOpenNoteFile(noteFilePath)
@@ -67,7 +67,7 @@ local OpenNoteAtCWD = function()
     local noteDirPath = utils.path.getNoteDirPathForCWD()
 
     -- get note file path
-    local noteFilePath = path:new(noteDirPath, fileName .. ".md").filename
+    local noteFilePath = path:new(noteDirPath, fileName .. "." .. utils.config.GetFileType()).filename
 
     -- check if note file exist
     checkAndOpenNoteFile(noteFilePath)

--- a/lua/quicknote/utils/config.lua
+++ b/lua/quicknote/utils/config.lua
@@ -2,6 +2,7 @@
 local config = {
     mode = "portable", -- "resident" or "portable"
     sign = "N",
+    filetype = "md"
 }
 
 -- Export
@@ -32,5 +33,10 @@ local GetSign = function()
     return config.sign
 end
 M.GetSign = GetSign
+
+local GetFileType = function()
+    return config.filetype
+end
+M.GetFileType = GetFileType
 
 return M


### PR DESCRIPTION

The changes affect the `NewNoteAtGlobalAsync`, `NewNoteAtCWDAsync`, `NewNote AtLineAsync`, `OpenNoteAtLine`, `OpenNoteAtGlobal`, `OpenNoteAtCWD`, `Delete NoteAtLine`, `DeleteNoteAtGlobal` and `DeleteNoteAtCWD` functions in `core`
 package, which now retrieve the file type from the configuration.

Additionally, `config.lua` in the `utils` package is updated to include a new
 `filetype` parameter.