### PR TITLE
feat: telescope integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A note can be associated with current cursor line, or current working directory,
 
 🎉 **All main features have already been implemented.** New features may probabily be introduced after fixing potential bugs, optimizing, and writing instruction/tutorial.
 
-- [x] In-place notes: no worrying about jumpping out of current workflow to take notes or managing the notes tediously. Just take notes in-place and make the notes associate with current cursor line, working directory or global directory.  
+- [x] In-place notes: no worrying about jumpping out of current workflow to take notes or managing the notes tediously. Just take notes in-place and make the notes associate with current cursor line, working directory or global directory.
 - [x] Jump between notes: easily jump between notes in current buffer.
 - [x] List notes: list the notes you have writen.
 - [x] Delete notes: delete notes you do not need quickly and in-place
@@ -52,7 +52,7 @@ Use any plugin manager you like.
 
 *Note: This plugin uses [nvim-lua/plenary.nvim](https://github.com/nvim-lua/plenary.nvim), thus please make sure it is in the dependencies or in your plugin list.*
 
-For lazy.nvim plugin manager: 
+For lazy.nvim plugin manager:
 
 ```lua
 require("lazy").setup({
@@ -75,7 +75,7 @@ require("lazy").setup({
             mode = "portable", -- "portable" | "resident", default to "portable"
             sign = "N", -- This is used for the signs on the left side (refer to ShowNoteSigns() api).
                        -- You can change it to whatever you want (eg. some nerd fonts icon), 'N' is default
-            filetype = "md", 
+            filetype = "md",
         })
   end
   , dependencies = { "nvim-lua/plenary.nvim"} },
@@ -107,6 +107,23 @@ There are two modes in quicknote.nvim, "resident" mode and "protable" mode. They
 2. **Pollution or not**:In resident mode, all notes, regardless of whether they are associated with files, CWD or global, will be put in `$XDG_STATE_PATH` and will never pollute your project. But in portable mode, since notes will be located in the `.quicknote` folder in your CWD, it may pollute your project if you consider it as a "pollution".
 2. **Portable or not**: In resident mode, the notes you have created will be hard to transfer to another computer. And if you move project which have notes associated with it to another computer or even another directory, all notes associated with it will be lost. But in protable note, you can transfer your project from one path to another or from one computer to another without worrying about lossing notes. You can even share the project with notes to your colleagues or friends who use Neovim and this plugin. They will be able to see the notes you have created.
 
+#### 3. Telescope.nvim integration
+
+If you use [nvim-telescope/telescope.nvim](https://github.com/nvim-telescope/telescope.nvim), you can use `:Telescope quicknote [scope=<Scope>]` to list all notes in given scope, `<Scope>` can be `CurrentBuffer`, `CWD` or `Global`.
+If you do not specify the scope
+, it will list with default scope which is `CWD` and can be changed in the telescope setup:
+```lua
+require("telescope").setup({
+    extensions = {
+        quicknote = {
+            defaultScope = "CWD",
+        }
+    }
+})
+
+require("telescope").load_extension("quicknote")
+```
+
 ## API
 
 I do not want to break any APIs when you are using this plugin, but it is still possible if some APIs are not rational or potential bugs force them to be changed. I may use semantic versioning later to avoid breaking APIs in the major version.
@@ -120,7 +137,7 @@ I do not want to break any APIs when you are using this plugin, but it is still 
 | `NewNoteAtCurrentLine()`| create a note at current cursor line|
 | `NewNoteAtGlobal` | create a note which can be accessed globally|
 
-2. Open note 
+2. Open note
 
 | Function | Description |
 | --- | ---|
@@ -175,8 +192,8 @@ I do not want to break any APIs when you are using this plugin, but it is still 
 | Funtion | Description |
 | --- | --- |
 | `ExportNotesForCurrentBuffer()` | export all notes associated with the current buffer to a destination dir |
-| `ExportNotesForCWD()` | export all notes associated with CWD, but notes associated with the files under CWD are not exported | 
-| `ExportNotesForGlobal()` | export all notes that have been put in global | 
+| `ExportNotesForCWD()` | export all notes associated with CWD, but notes associated with the files under CWD are not exported |
+| `ExportNotesForGlobal()` | export all notes that have been put in global |
 
 9. Import notes
 

--- a/lua/telescope/_extensions/quicknote.lua
+++ b/lua/telescope/_extensions/quicknote.lua
@@ -1,0 +1,72 @@
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+local conf = require("telescope.config").values
+
+local utils = require("quicknote.utils")
+local path = require("plenary.path")
+
+local listNotes = function(noteDirPath)
+    if not vim.loop.fs_stat(noteDirPath) then
+        return
+    end
+    local notes = {}
+    local noteFilePaths = vim.fn.glob(noteDirPath .. "/*." .. utils.config.GetFileType(), true, true)
+    if noteFilePaths and #noteFilePaths ~= 0 then
+        for _, noteFilePath in ipairs(noteFilePaths) do
+            local dirNameList = path._split(path:new(noteFilePath))
+            local fileName = dirNameList[#dirNameList]
+            table.insert(notes, {
+                name = fileName,
+                path = noteFilePath,
+            })
+        end
+    end
+    return notes
+end
+
+local finder = function(scope)
+    if utils.config.GetMode() ~= "resident" and scope == "Global" then
+        error("Global scope is only available in resident mode")
+    end
+    local func = "getNoteDirPathFor" .. scope
+    local noteDirPath = utils.path[func]()
+    local notes = listNotes(noteDirPath)
+    if not notes or #notes == 0 then
+        error("No notes found")
+    end
+    return finders.new_table({
+        results = notes,
+        entry_maker = function(entry)
+            local name = entry.name
+            return {
+                value = entry.path,
+                display = name,
+                ordinal = name,
+            }
+        end,
+    })
+end
+
+local options = {
+    defaultScope = "CWD",
+}
+
+return require("telescope").register_extension({
+    setup = function(opts)
+        options = vim.tbl_extend("force", options, opts)
+    end,
+    exports = {
+        quicknote = function(opts)
+            opts = opts or {}
+            local scope = opts.scope or options.defaultScope
+            pickers
+                .new(opts, {
+                    prompt_title = "Quick Notes for " .. scope,
+                    finder = finder(scope),
+                    previewer = conf.file_previewer(opts),
+                    sorter = conf.generic_sorter(opts),
+                })
+                :find()
+        end,
+    },
+})


### PR DESCRIPTION
This PR add a simple telescope cmd to list notes: `Telescope quicknote scope=<Scope>`. The scope can be `CWD`, `CurrentBuffer`, `Global`. If the scope is not specified, use the defaults value `defaultScope` instead. And the `defaultScope` can be set as telescope extension option.

BTW, there are some unrelated changes in README, because trailing whitespaces are removed by neovim automatically.

