### PR TITLE
feat: Use configured filetype for signs

### DIFF
--- a/lua/quicknote/core/sign.lua
+++ b/lua/quicknote/core/sign.lua
@@ -46,7 +46,8 @@ function M.ShowNoteSigns()
     local noteDirPath = utils_path.getNoteDirPathForCurrentBuffer()
 
     -- get all notes under this path
-    local noteFilePaths = vim.fn.glob(noteDirPath .. "/*.md", true, true)
+    local noteFileType = utils_config.GetFileType()
+    local noteFilePaths = vim.fn.glob(noteDirPath .. "/*." .. noteFileType , true, true)
     if noteFilePaths == nil or #noteFilePaths <= 0 then
         return
     end


### PR DESCRIPTION
Hey I noticed that sign column wouldn't show a note despite the note existing. I did some digging and discovered that it only checked for markdown files. I made a change so it would use whatever file type is configured in the users config. If you'd like it done differently or anything like that let me know and I can fix it.