### PR TITLE
🔧 fix: Update fs_stat source and use path in telescope entry maker

### DIFF
--- a/lua/telescope/_extensions/quicknote.lua
+++ b/lua/telescope/_extensions/quicknote.lua
@@ -7,7 +7,7 @@ local path = require("plenary.path")
 
 local listNotes = function(noteDirPath)
     local notes = {}
-    if not vim.loop.fs_stat(noteDirPath) then
+    if not (vim.uv or vim.loop).fs_stat(noteDirPath) then
         return notes
     end
     local noteFilePaths = vim.fn.glob(noteDirPath .. "/*." .. utils.config.GetFileType(), true, true)
@@ -39,7 +39,7 @@ local finder = function(scope)
         entry_maker = function(entry)
             local name = entry.name
             return {
-                value = entry.path,
+                path = entry.path,
                 display = name,
                 ordinal = name,
             }


### PR DESCRIPTION
- Updated the fs_stat check to handle both `vim.uv` and `vim.loop`.
- Fixed the entry_maker function to use the `path` field instead of `value`.